### PR TITLE
fix spaceCount calculation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,11 @@ export function parsePageItems(pdfItems: TextItem[]): Page {
             const xDiff = item.transform[4] - (lastItem.transform[4] + lastItem.width);
 
             // insert spaces for items that are far apart horizontally
-            if (item.height !== 0 && (xDiff > item.height || xDiff > lastItem.height)) {
+            if (
+                item.height !== 0 &&
+                lastItem.height !== 0 &&
+                (xDiff > item.height || xDiff > lastItem.height)
+            ) {
                 const spaceCountA = Math.ceil(xDiff / item.height);
                 let spaceCount = spaceCountA;
                 if (lastItem.height !== item.height) {


### PR DESCRIPTION
Hi! Thank you for this repository (:.

It seems we encountered a bug with my colleagues (cc: @LuisCardosoOliveira).

The error was:
```
    RangeError: Invalid array length
      at parsePageItems (node_modules/pdf-text-reader/dist/index.js:93:25)
      at parsePage (node_modules/pdf-text-reader/dist/index.js:31:12)
      at async readPdfText (node_modules/pdf-text-reader/dist/index.js:17:20)
```

---

After investigating a little, it seems like `lastItem.height` can be equal to 0.

This leads to spaceCount being equal to `Infinity` (from line: )
https://github.com/electrovir/pdf-text-reader/blob/06c35be5c7532777c9ce619334d34152d0dda424/src/index.ts#L156

As we're doing an `Array(spaceCount)` afterwards, it makes the library throw an error.
https://github.com/electrovir/pdf-text-reader/blob/06c35be5c7532777c9ce619334d34152d0dda424/src/index.ts#L159

---

Adding a condition on `lastItem.height !== 0` corrects the behavior.

---

`npm run test` was launched and didn't return any errors. Please feel free to tell us if it's OK for you!